### PR TITLE
53 integrate gqltada for type safe graphql

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ Examensarbete-2026.sln.DotSettings.user
 /RSSFeedReader/obj/RSSFeedReader.csproj.nuget.dgspec.json
 /RSSFeedReader/obj/RSSFeedReader.csproj.nuget.g.props
 /RSSFeedReader/obj/RSSFeedReader.csproj.nuget.g.targets
+frontend/schema.graphql
+frontend/src/graphql-env.d.ts

--- a/AppHost/AppHost.cs
+++ b/AppHost/AppHost.cs
@@ -24,4 +24,8 @@ builder.AddNextJsApp("frontend", "../frontend")
     .WithExternalHttpEndpoints();
 #pragma warning restore ASPIREJAVASCRIPT001
 
+builder.AddJavaScriptApp("update-graphql-schema", "../frontend", "updateGraphql")
+    .WithReference(backend)
+    .WaitFor(backend);
+
 builder.Build().Run();

--- a/frontend/.vscode/extensions.json
+++ b/frontend/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+    "recommendations": ["graphql.vscode-graphql-syntax"]
+}

--- a/frontend/.vscode/settings.json
+++ b/frontend/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "typescript.tsdk": "node_modules/typescript/lib",
+    "typescript.enablePromptUseWorkspaceTsdk": true
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,12 +11,15 @@
                 "@fortawesome/fontawesome-svg-core": "^7.2.0",
                 "@fortawesome/free-solid-svg-icons": "^7.2.0",
                 "@fortawesome/react-fontawesome": "^3.3.1",
+                "gql.tada": "^1.9.2",
+                "graphql-request": "^7.4.0",
                 "next": "16.2.4",
                 "react": "19.2.4",
                 "react-dom": "19.2.4",
                 "zod": "^4.4.3"
             },
             "devDependencies": {
+                "@0no-co/graphqlsp": "^1.15.4",
                 "@types/node": "^20",
                 "@types/react": "^19",
                 "@types/react-dom": "^19",
@@ -25,6 +28,34 @@
                 "eslint-config-next": "16.2.4",
                 "prettier": "3.8.3",
                 "typescript": "^5"
+            }
+        },
+        "node_modules/@0no-co/graphql.web": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@0no-co/graphql.web/-/graphql.web-1.2.0.tgz",
+            "integrity": "sha512-/1iHy9TTr63gE1YcR5idjx8UREz1s0kFhydf3bBLCXyqjhkIc6igAzTOx3zPifCwFR87tsh/4Pa9cNts6d2otw==",
+            "license": "MIT",
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+            },
+            "peerDependenciesMeta": {
+                "graphql": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@0no-co/graphqlsp": {
+            "version": "1.15.4",
+            "resolved": "https://registry.npmjs.org/@0no-co/graphqlsp/-/graphqlsp-1.15.4.tgz",
+            "integrity": "sha512-Nt1DVHcZ08lKRKwhiU0amXH77fSdrO6DzyjLE0DkCxfbM/N1SAs32d76y1xtCzM5H9eT0iDS7SdksgRXWJu05g==",
+            "license": "MIT",
+            "dependencies": {
+                "@gql.tada/internal": "^1.0.0",
+                "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0"
+            },
+            "peerDependencies": {
+                "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0",
+                "typescript": "^5.0.0 || ^6.0.0"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -488,6 +519,54 @@
             "peerDependencies": {
                 "@fortawesome/fontawesome-svg-core": "~6 || ~7",
                 "react": "^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/@gql.tada/cli-utils": {
+            "version": "1.7.3",
+            "resolved": "https://registry.npmjs.org/@gql.tada/cli-utils/-/cli-utils-1.7.3.tgz",
+            "integrity": "sha512-3iQY5E/jvv3Lnh6D1Mh7zr+Bb9C/TGk1DHkm+lbIjQBnZAu2m+BcTcr1e3spUt6Aa6HG/xAN2XxpbWw9oZALEg==",
+            "license": "MIT",
+            "dependencies": {
+                "@0no-co/graphqlsp": "^1.12.13",
+                "@gql.tada/internal": "1.0.9",
+                "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0"
+            },
+            "peerDependencies": {
+                "@0no-co/graphqlsp": "^1.12.13",
+                "@gql.tada/svelte-support": "1.0.2",
+                "@gql.tada/vue-support": "1.0.2",
+                "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0",
+                "typescript": "^5.0.0 || ^6.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@gql.tada/svelte-support": {
+                    "optional": true
+                },
+                "@gql.tada/vue-support": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@gql.tada/internal": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/@gql.tada/internal/-/internal-1.0.9.tgz",
+            "integrity": "sha512-Bp8yi+kLrzIJ3l5Dfxhz48H4OCH2LCX+pShaPcJgh+oiBt6clrjUKDYNDD3Z78aDQ3+Tyrxe4dd0MfLgpSLPPg==",
+            "license": "MIT",
+            "dependencies": {
+                "@0no-co/graphql.web": "^1.0.5"
+            },
+            "peerDependencies": {
+                "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0",
+                "typescript": "^5.0.0 || ^6.0.0"
+            }
+        },
+        "node_modules/@graphql-typed-document-node/core": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
+            "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
+            "license": "MIT",
+            "peerDependencies": {
+                "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
             }
         },
         "node_modules/@humanfs/core": {
@@ -3559,6 +3638,46 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/gql.tada": {
+            "version": "1.9.2",
+            "resolved": "https://registry.npmjs.org/gql.tada/-/gql.tada-1.9.2.tgz",
+            "integrity": "sha512-QxRHVpxtrOVdYXz6oavq0lBM+Zdp0swapLGJcD4SLpXDcsD337BHDFrzqqjfkbepv0sSAiO0LGabu1kI5D5Gyg==",
+            "license": "MIT",
+            "dependencies": {
+                "@0no-co/graphql.web": "^1.0.5",
+                "@0no-co/graphqlsp": "^1.12.13",
+                "@gql.tada/cli-utils": "1.7.3",
+                "@gql.tada/internal": "1.0.9"
+            },
+            "bin": {
+                "gql-tada": "bin/cli.js",
+                "gql.tada": "bin/cli.js"
+            },
+            "peerDependencies": {
+                "typescript": "^5.0.0 || ^6.0.0"
+            }
+        },
+        "node_modules/graphql": {
+            "version": "16.14.1",
+            "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.1.tgz",
+            "integrity": "sha512-cQOsSMS/IrDz82PVyRDvf/Q1F/bRbBVjJlh+xYOkI1qw2bWRvWGiWc+m2O0d6l4Bt1fyY+8kzJ8JFWGJqNeDBg==",
+            "license": "MIT",
+            "engines": {
+                "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+            }
+        },
+        "node_modules/graphql-request": {
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-7.4.0.tgz",
+            "integrity": "sha512-xfr+zFb/QYbs4l4ty0dltqiXIp07U6sl+tOKAb0t50/EnQek6CVVBLjETXi+FghElytvgaAWtIOt3EV7zLzIAQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@graphql-typed-document-node/core": "^3.2.0"
+            },
+            "peerDependencies": {
+                "graphql": "14 - 16"
+            }
+        },
         "node_modules/has-bigints": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -5727,7 +5846,6 @@
             "version": "5.9.3",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-            "dev": true,
             "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
                 "@fortawesome/fontawesome-svg-core": "^7.2.0",
                 "@fortawesome/free-solid-svg-icons": "^7.2.0",
                 "@fortawesome/react-fontawesome": "^3.3.1",
+                "dotenv": "^17.4.2",
                 "gql.tada": "^1.9.2",
                 "graphql-request": "^7.4.0",
                 "next": "16.2.4",
@@ -2673,6 +2674,18 @@
             },
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/dotenv": {
+            "version": "17.4.2",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+            "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://dotenvx.com"
             }
         },
         "node_modules/dunder-proto": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,12 +6,14 @@
         "dev": "next dev",
         "build": "next build",
         "start": "next start",
-        "lint": "eslint"
+        "lint": "eslint",
+        "updateGraphql": "npx tsx scripts/gql.ts"
     },
     "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^7.2.0",
         "@fortawesome/free-solid-svg-icons": "^7.2.0",
         "@fortawesome/react-fontawesome": "^3.3.1",
+        "dotenv": "^17.4.2",
         "gql.tada": "^1.9.2",
         "graphql-request": "^7.4.0",
         "next": "16.2.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,12 +12,15 @@
         "@fortawesome/fontawesome-svg-core": "^7.2.0",
         "@fortawesome/free-solid-svg-icons": "^7.2.0",
         "@fortawesome/react-fontawesome": "^3.3.1",
+        "gql.tada": "^1.9.2",
+        "graphql-request": "^7.4.0",
         "next": "16.2.4",
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "zod": "^4.4.3"
     },
     "devDependencies": {
+        "@0no-co/graphqlsp": "^1.15.4",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",

--- a/frontend/scripts/gql.ts
+++ b/frontend/scripts/gql.ts
@@ -1,0 +1,24 @@
+import "dotenv/config";
+import { execSync } from "child_process";
+
+const backendEndpoint = process.env.BACKEND_HTTPS;
+
+if (!backendEndpoint) {
+    console.error("❌ Could not find backendEndpoint!");
+    process.exit(1);
+}
+
+const GraphQLEndPoint = `${backendEndpoint}/graphql/`;
+
+try {
+    console.log("Starting generate .graphql");
+    execSync(
+        `npx gql-tada generate-schema -o ./schema.graphql ${GraphQLEndPoint}`,
+    );
+
+    console.log("Making the graphql ts types");
+    execSync("npx gql-tada generate-output");
+} catch (error) {
+    console.error("❌ Misslyckades med att generera gql-tada filer:", error);
+    process.exit(1);
+}

--- a/frontend/src/gql/index.ts
+++ b/frontend/src/gql/index.ts
@@ -1,0 +1,18 @@
+import { introspection } from "@/graphql-env";
+import { initGraphQLTada } from "gql.tada";
+import { GraphQLClient } from "graphql-request";
+
+const endpoint = `${process.env.services__backend__https__0}/graphql`;
+
+export const client = (headers?: Headers) =>
+    new GraphQLClient(endpoint, {
+        headers,
+    });
+
+export const graphql = initGraphQLTada<{
+    introspection: introspection;
+    scalars: {
+        DateTime: Date;
+        JSON: string;
+    };
+}>();

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -16,6 +16,11 @@
         "plugins": [
             {
                 "name": "next"
+            },
+            {
+                "name": "@0no-co/graphqlsp",
+                "schema": "./schema.graphql",
+                "tadaOutputLocation": "./src/graphql-env.d.ts"
             }
         ],
         "paths": {


### PR DESCRIPTION
This pull request introduces a new workflow for generating and consuming GraphQL types in the frontend, improves the developer experience with VSCode, and adds several new dependencies to support GraphQL development. The most important changes are grouped below.

**GraphQL Type Generation and Integration**

* Added a new script `scripts/gql.ts` that fetches the GraphQL schema from the backend and generates TypeScript types using `gql.tada`. This script is referenced as `updateGraphql` in `frontend/package.json` and is integrated into the app host build process. [[1]](diffhunk://#diff-0677c98c77a5fe87d3147746b81e32d0c1c477b4810f2d7ba80985bb6fb825d3R1-R24) [[2]](diffhunk://#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655L9-R25) [[3]](diffhunk://#diff-2f7e33235dcca3425a9432b61c127e5d0e1a14683c0bc068f636f4bd73c31c39R27-R30)
* Added a new module `src/gql/index.ts` that initializes the GraphQL client and type-safe query utilities for the frontend, using the generated types and schema.
* Updated `tsconfig.json` to include the `@0no-co/graphqlsp` plugin for type generation, pointing to the generated schema and output location.

**Dependency and Tooling Updates**

* Added several new dependencies to `frontend/package.json` and `package-lock.json`, including `gql.tada`, `graphql-request`, `dotenv`, and supporting GraphQL codegen libraries, to enable schema fetching and type generation. [[1]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aR14-R23) [[2]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aR34-R61) [[3]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aR525-R572) [[4]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aR2679-R2690) [[5]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aR3654-R3693)
* Added VSCode workspace recommendations for the GraphQL syntax extension and configured TypeScript to use the workspace version, improving the developer experience. [[1]](diffhunk://#diff-f166a36bf3fedd08906a7493b7d72efb24e16d21552b0a269cd9c1ea6d325e67R1-R3) [[2]](diffhunk://#diff-db52d6d894f5effbce127be224e304d8fb5995bfd2cdaffa966fc230ded19424R1-R4)